### PR TITLE
Add missing attributes to PhoneNumber

### DIFF
--- a/lib/bandwidth/voice_lib/bxml/verbs/phone_number.rb
+++ b/lib/bandwidth/voice_lib/bxml/verbs/phone_number.rb
@@ -8,6 +8,8 @@ module Bandwidth
         xml.PhoneNumber(number, compact_hash({
           'transferAnswerUrl' => transfer_answer_url,
           'transferAnswerMethod' => transfer_answer_method,
+          'transferDisconnectUrl' => transfer_disconnect_url,
+          'transferDisconnectMethod' => transfer_disconnect_method,
           'username' => username,
           'password' => password,
           'tag' => tag


### PR DESCRIPTION
The [documentation](https://dev.bandwidth.com/voice/bxml/verbs/transfer.html) states that the `PhoneNumber` can also take `transferDisconnectMethod` and `transferDisconnectUrl`.  This change adds those properties.