### PR TITLE
EDGE-630 Add voice_call_id to generate_transfer_bxml_verb

### DIFF
--- a/bandwidth.gemspec
+++ b/bandwidth.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'bandwidth-sdk'
-  s.version = '7.1.0'
+  s.version = '8.0.0'
   s.summary = 'bandwidth'
   s.description = 'Bandwidth\'s set of APIs'
   s.authors = ['APIMatic SDK Generator']

--- a/lib/bandwidth/web_rtc_lib/utils/web_rtc_transfer.rb
+++ b/lib/bandwidth/web_rtc_lib/utils/web_rtc_transfer.rb
@@ -6,12 +6,12 @@
 
 module Bandwidth
   module WebRtc
-    def generate_bxml(device_token, sip_uri="sip:sipx.webrtc.bandwidth.com:5060")
-        return '<?xml version="1.0" encoding="UTF-8"?><Response>' + generate_transfer_bxml_verb(device_token, sip_uri) + '</Response>'
+    def generate_bxml(device_token, voice_call_id, sip_uri="sip:sipx.webrtc.bandwidth.com:5060")
+        return '<?xml version="1.0" encoding="UTF-8"?><Response>' + generate_transfer_bxml_verb(device_token, voice_call_id, sip_uri) + '</Response>'
     end
 
-    def generate_transfer_bxml_verb(device_token, sip_uri="sip:sipx.webrtc.bandwidth.com:5060")
-        return '<Transfer><SipUri uui="%s;encoding=jwt">%s</SipUri></Transfer>' % [device_token, sip_uri]
+    def generate_transfer_bxml_verb(device_token, voice_call_id, sip_uri="sip:sipx.webrtc.bandwidth.com:5060")
+        return '<Transfer><SipUri uui="%s;encoding=base64,%s;encoding=jwt">%s</SipUri></Transfer>' % [device_token, voice_call_id, sip_uri]
     end
   end
 end

--- a/lib/bandwidth/web_rtc_lib/utils/web_rtc_transfer.rb
+++ b/lib/bandwidth/web_rtc_lib/utils/web_rtc_transfer.rb
@@ -11,7 +11,8 @@ module Bandwidth
     end
 
     def generate_transfer_bxml_verb(device_token, voice_call_id, sip_uri="sip:sipx.webrtc.bandwidth.com:5060")
-        return '<Transfer><SipUri uui="%s;encoding=base64,%s;encoding=jwt">%s</SipUri></Transfer>' % [device_token, voice_call_id, sip_uri]
+        voice_call_id = voice_call_id.split("-", 2).last.split("-").join()
+        return '<Transfer><SipUri uui="%s;encoding=base64,%s;encoding=jwt">%s</SipUri></Transfer>' % [voice_call_id, device_token, sip_uri]
     end
   end
 end

--- a/test/integration/test_integration.rb
+++ b/test/integration/test_integration.rb
@@ -583,14 +583,14 @@ class IntegrationTest < Test::Unit::TestCase
     end
 
     def test_webrtc_generate_bxml
-        expected = '<?xml version="1.0" encoding="UTF-8"?><Response><Transfer><SipUri uui="asdf;encoding=jwt">sip:sipx.webrtc.bandwidth.com:5060</SipUri></Transfer></Response>'
-        actual = Bandwidth::WebRtc.generate_bxml('asdf')
+        expected = '<?xml version="1.0" encoding="UTF-8"?><Response><Transfer><SipUri uui="93d6f3c0be5845960b744fa28015d8ede84bd1a4;encoding=base64,asdf;encoding=jwt">sip:sipx.webrtc.bandwidth.com:5060</SipUri></Transfer></Response>'
+        actual = Bandwidth::WebRtc.generate_bxml('asdf', 'c-93d6f3c0-be584596-0b74-4fa2-8015-d8ede84bd1a4')
         assert_equal(expected, actual)
     end
 
     def test_webrtc_generate_transfer_bxml_verb
-        expected = '<Transfer><SipUri uui="asdf;encoding=jwt">sip:sipx.webrtc.bandwidth.com:5060</SipUri></Transfer>'
-        actual = Bandwidth::WebRtc.generate_transfer_bxml_verb('asdf')
+        expected = '<Transfer><SipUri uui="93d6f3c0be5845960b744fa28015d8ede84bd1a4;encoding=base64,asdf;encoding=jwt">sip:sipx.webrtc.bandwidth.com:5060</SipUri></Transfer>'
+        actual = Bandwidth::WebRtc.generate_transfer_bxml_verb('asdf', 'c-93d6f3c0-be584596-0b74-4fa2-8015-d8ede84bd1a4')
         assert_equal(expected, actual)
     end
 end


### PR DESCRIPTION
I just noticed a few items I need to fix.

This is a breaking change so it should go out with a major version bump.