### PR TITLE
Task: Update Manteca Test Ids

### DIFF
--- a/spec/call_utils.rb
+++ b/spec/call_utils.rb
@@ -12,7 +12,7 @@ def setup_manteca(type)
   
     begin
       test_id = Net::HTTP.post(manteca_test_url, manteca_body.to_json, manteca_header)
-      return test_id.body.to_s.gsub("\"", "")
+      return test_id.body.to_s
     rescue => e
       puts e.inspect
     end


### PR DESCRIPTION
Updating tests to account for new Manteca return type (current tests will fail until Manteca change merged).