### PR TITLE
Add a debug logging.

### DIFF
--- a/lib/bandwidth/configuration.rb
+++ b/lib/bandwidth/configuration.rb
@@ -29,7 +29,7 @@ module Bandwidth
   class Configuration
     # The attribute readers for properties.
     attr_reader :http_client, :timeout, :max_retries, :retry_interval, :backoff_factor,
-                :retry_statuses, :retry_methods, :environment, :base_url,
+                :retry_statuses, :retry_methods, :request_debug_log, :environment, :base_url,
                 :messaging_basic_auth_user_name, :messaging_basic_auth_password,
                 :multi_factor_auth_basic_auth_user_name, :multi_factor_auth_basic_auth_password,
                 :phone_number_lookup_basic_auth_user_name, :phone_number_lookup_basic_auth_password,
@@ -44,6 +44,7 @@ module Bandwidth
                    backoff_factor: 2,
                    retry_statuses: [408, 413, 429, 500, 502, 503, 504, 521, 522, 524, 408, 413, 429, 500, 502, 503, 504, 521, 522, 524],
                    retry_methods: %i[get put get put],
+                   request_debug_log: false,
                    environment: Environment::PRODUCTION,
                    base_url: 'https://www.example.com',
                    messaging_basic_auth_user_name: 'TODO: Replace',
@@ -74,6 +75,9 @@ module Bandwidth
 
       # A list of HTTP methods to retry
       @retry_methods = retry_methods
+
+      # A flag to enable/disable request debug logging
+      @request_debug_log = request_debug_log
 
       # Current API environment
       @environment = String(environment)
@@ -117,6 +121,7 @@ module Bandwidth
 
     def clone_with(timeout: nil, max_retries: nil, retry_interval: nil,
                    backoff_factor: nil, retry_statuses: nil, retry_methods: nil,
+                   request_debug_log: nil,
                    environment: nil, base_url: nil,
                    messaging_basic_auth_user_name: nil,
                    messaging_basic_auth_password: nil,
@@ -134,6 +139,7 @@ module Bandwidth
       backoff_factor ||= self.backoff_factor
       retry_statuses ||= self.retry_statuses
       retry_methods ||= self.retry_methods
+      request_debug_log ||= self.request_debug_log
       environment ||= self.environment
       base_url ||= self.base_url
       messaging_basic_auth_user_name ||= self.messaging_basic_auth_user_name
@@ -151,6 +157,7 @@ module Bandwidth
         timeout: timeout, max_retries: max_retries,
         retry_interval: retry_interval, backoff_factor: backoff_factor,
         retry_statuses: retry_statuses, retry_methods: retry_methods,
+        request_debug_log: request_debug_log,
         environment: environment, base_url: base_url,
         messaging_basic_auth_user_name: messaging_basic_auth_user_name,
         messaging_basic_auth_password: messaging_basic_auth_password,
@@ -170,7 +177,8 @@ module Bandwidth
                         retry_interval: retry_interval,
                         backoff_factor: backoff_factor,
                         retry_statuses: retry_statuses,
-                        retry_methods: retry_methods)
+                        retry_methods: retry_methods,
+                        request_debug_log: request_debug_log)
     end
 
     # All the environments the SDK can run in.

--- a/lib/bandwidth/http/faraday_client.rb
+++ b/lib/bandwidth/http/faraday_client.rb
@@ -14,6 +14,7 @@ module Bandwidth
     # The constructor.
     def initialize(timeout:, max_retries:, retry_interval:,
                    backoff_factor:, retry_statuses:, retry_methods:,
+                   request_debug_log: false,
                    cache: false, verify: true)
       @connection = Faraday.new do |faraday|
         faraday.use Faraday::HttpCache, serializer: Marshal if cache
@@ -25,7 +26,14 @@ module Bandwidth
                                 backoff_factor: backoff_factor,
                                 retry_statuses: retry_statuses,
                                 methods: retry_methods
+
+        # this should only be used for debug purposes because it includes all headers including authorization
+        if request_debug_log
+          faraday.response :logger, nil, { headers: true, bodies: true, errors: true }
+        end
+
         faraday.adapter Faraday.default_adapter
+
         faraday.options[:params_encoder] = Faraday::FlatParamsEncoder
         faraday.options[:timeout] = timeout if timeout.positive?
       end


### PR DESCRIPTION
Hello! We're trying to use bandwidth for the first time, thanks for your help already in https://github.com/Bandwidth/ruby-bandwidth-iris/pull/74

We're now trying to send a message using the Account we provisioned via the iris gem.

We received the error message from  ruby-sdk the gem: ` Bandwidth::MessagingException: 403 The user does not have access to this API` when we tried to send a message. 

We expect this might be a permission problem? However, Bandwidth Support indicates that the only way to know the root cause of this issue is to send the raw HTTP requests we're making to the API. It's not currently possible to do that using the ruby gem, so I've tried to add support for Faraday logging as a config option. 

I'm not sure however that this is the right approach? The code looks like it might be generated from a specification file -- so something may need to be added to the template?

Let us know the best approach to proceed, is this something that needs to happen in APIMATIC? I'm not familiar with this tool.